### PR TITLE
Add utils to print a hex nibble or word

### DIFF
--- a/bp_utils.c
+++ b/bp_utils.c
@@ -45,15 +45,24 @@ void bp_finish(uint8_t code) {
   *(FINISH_BASE_ADDR+core_id*8) = code;
 }
 
-void bp_hprint(uint8_t hex) {
-
-  *(PUTCHAR_BASE_ADDR) = ('0' + hex);
+void bp_hprint(uint8_t nibble) {
+  if (nibble <= 0x9) {
+    bp_cprint('0' + nibble);
+  } else if (nibble <= 0xf) {
+    bp_cprint('a' + nibble - 0xa);
+  }
 }
 
 void bp_cprint(uint8_t ch) {
-
   *(PUTCHAR_BASE_ADDR) = ch;
 }
 
-
-
+void bp_hprint_uint64(uint64_t val) {
+  bp_cprint('0');
+  bp_cprint('x');
+  for (int i = 0; i < 16; i++) {
+    uint8_t nibble = val >> 60;
+    bp_hprint(nibble);
+    val <<= 4;
+  }
+}

--- a/bp_utils.h
+++ b/bp_utils.h
@@ -18,9 +18,14 @@ uint64_t bp_get_hart();
 
 void bp_barrier_end(volatile uint64_t *barrier_address, uint64_t total_num_cores);
 
-void bp_hprint(uint8_t hex);
+// Prints the given nibble as a hex character. 0 <= nibble <= 0xf.
+void bp_hprint(uint8_t nibble);
 
+// Prints the provided ASCII character.
 void bp_cprint(uint8_t ch);
+
+// Prints the given value as a 16-nibble hex number, preceded by "0x".
+void bp_hprint_uint64(uint64_t val);
 
 void bp_finish(uint8_t code);
 


### PR DESCRIPTION
This is a port of some helpers I think might be useful to have in the lib.

This PR changes the behavior of `bp_hprint`; values >15 will no longer be printed, and values 10 through 15 will be letters. The three usages -- `sample.c` in bp-demos, `copy_example.c` in bp-tests and `atomic_queue_demo.c` in bp-tests -- should also be fine as-is, although the latter might want to use the `_uint64` version anyway if the size parameter is later changed.

Fixes black-parrot/black-parrot#849