### PR TITLE
Explicitly check mcause in trap handler

### DIFF
--- a/bp_utils.c
+++ b/bp_utils.c
@@ -73,3 +73,19 @@ void bp_hprint_uint64(uint64_t val) {
     val <<= 4;
   }
 }
+
+void bp_print_string(char *str) {
+  while (*str) {
+    bp_cprint(*str);
+    str++;
+  }
+}
+
+void bp_panic(char *message) {
+  if (message) {
+    bp_print_string(message);
+  }
+
+  bp_finish(1);
+  while (1);
+}

--- a/bp_utils.h
+++ b/bp_utils.h
@@ -29,6 +29,10 @@ void bp_hprint_uint64(uint64_t val);
 
 void bp_finish(uint8_t code);
 
+void bp_print_string(char *str);
+
+void bp_panic(char *message);
+
 #define BP_CFG_BASE_ADDR ((char *)(0x00200000))
 
 #ifdef __cplusplus

--- a/emulation.h
+++ b/emulation.h
@@ -1,5 +1,5 @@
 
-extern void decode_illegal(uint64_t*, uint64_t, uint64_t);
+extern void bp_emulate_illegal_instruction(uint64_t*, uint64_t, uint64_t);
 
 extern uint64_t amo_swapd(uint64_t, uint64_t);
 extern uint64_t amo_swapw(uint64_t, uint64_t);
@@ -31,3 +31,5 @@ extern uint64_t amo_maxud(uint64_t, uint64_t);
 extern uint64_t mul_mulh(uint64_t, uint64_t);
 extern uint64_t mul_mulhsu(uint64_t, uint64_t);
 extern uint64_t mul_mulhu(uint64_t, uint64_t);
+
+void bp_unhandled_trap_abort(uint64_t *regs, uint64_t mcause, uint64_t mtval);

--- a/exception.S
+++ b/exception.S
@@ -4,8 +4,7 @@
 .align 1
 .globl __mtvec_handler
 
-.globl decode_illegal
-.type  decode_illegal, @function
+#define MCAUSE_ILLEGAL_INSTRUCTION 0x2
 
 __mtvec_handler:
     # Swap in the machine mode stack pointer
@@ -50,17 +49,26 @@ __mtvec_handler:
     sd x1, -240(sp)
     sd x0, -248(sp)
 
-    # Adjust the stack    
+    # Adjust the stack
     addi sp, sp, -256 
 
-    ## Decode the faulting instruction
+    ## Handle the exception if able, e.g. emulate software-assisted instructions
     # Save a pointer to the registers
     addi a0, sp, 8
-    # Read the faulting instruction
+    # Read the exception code
     csrr a1, mcause
     # Read the trap value
-    csrr a2, mbadaddr
-    jal decode_illegal
+    csrr a2, mtval
+
+    # return from handler directly to .Lfinish
+    la ra, .Lfinish
+
+    # Invoke the appropriate handler
+    li t0, MCAUSE_ILLEGAL_INSTRUCTION
+    beq a1, t0, bp_emulate_illegal_instruction
+    j bp_unhandled_trap_abort
+
+.Lfinish:
 
     # Return address is the instruction after MEPC
     csrr t0, mepc


### PR DESCRIPTION
This PR introduces a distinction between exceptions we don't know how to handle and illegal instructions we don't know how to emulate. `mcause` is now explicitly checked by the handler. This should have no functional effect other than clarity.

I'd also be interested in replacing the two `while (1);` branches with something that can report the error. If there's a suggestion for how that would make sense I'd be happy to implement it.