### PR TITLE
Fence all I/O after writing bp_finish

### DIFF
--- a/bp_utils.c
+++ b/bp_utils.c
@@ -29,6 +29,8 @@ void bp_finish(uint8_t code) {
   uint64_t core_id = bp_get_hart();
 
   *(FINISH_BASE_ADDR+core_id*8) = code;
+  __asm__ volatile("fence");
+  while (1);
 }
 
 void bp_hprint(uint8_t nibble) {


### PR DESCRIPTION
Previously, instructions that followed may have been executed by the time the "finish" took effect.

"fence" pseudoinstruction expands to `fence iorw, iorw`.