### PR TITLE
Add generic trap handler

### DIFF
--- a/bp_trap.c
+++ b/bp_trap.c
@@ -1,0 +1,86 @@
+#include <stdint.h>
+#include "bp_trap.h"
+#include "emulation.h"
+
+#define EXCEPTION_TOTAL            16
+#define INTERRUPT_TOTAL            12
+
+static void (*exception_handler[EXCEPTION_TOTAL])(uint64_t *, uint64_t, uint64_t) =
+{
+  bp_unhandled_trap_abort,        // 0
+  bp_unhandled_trap_abort,        // 1
+  bp_emulate_illegal_instruction, // 2
+  bp_unhandled_trap_abort,        // 3
+  bp_unhandled_trap_abort,        // 4
+  bp_unhandled_trap_abort,        // 5
+  bp_unhandled_trap_abort,        // 6
+  bp_unhandled_trap_abort,        // 7
+  bp_unhandled_trap_abort,        // 8
+  bp_unhandled_trap_abort,        // 9
+  bp_unhandled_trap_abort,        // 10
+  bp_unhandled_trap_abort,        // 11
+  bp_unhandled_trap_abort,        // 12
+  bp_unhandled_trap_abort,        // 13
+  bp_unhandled_trap_abort,        // 14
+  bp_unhandled_trap_abort         // 15
+};
+
+static void (*interrupt_handler[INTERRUPT_TOTAL])(uint64_t *, uint64_t, uint64_t) =
+{
+  bp_unhandled_trap_abort,        // 0
+  bp_unhandled_trap_abort,        // 1
+  bp_unhandled_trap_abort,        // 2
+  bp_unhandled_trap_abort,        // 3
+  bp_unhandled_trap_abort,        // 4
+  bp_unhandled_trap_abort,        // 5
+  bp_unhandled_trap_abort,        // 6
+  bp_unhandled_trap_abort,        // 7
+  bp_unhandled_trap_abort,        // 8
+  bp_unhandled_trap_abort,        // 9
+  bp_unhandled_trap_abort,        // 10
+  bp_unhandled_trap_abort,        // 11
+};
+
+int register_trap_handler(void (*handler)(uint64_t *, uint64_t, uint64_t),
+        int index, int is_exception)
+{
+  if(is_exception) {
+    // exception handler registration
+    if(index >= 0 && index < EXCEPTION_TOTAL) {
+      exception_handler[index] = handler;
+      return 0; // success
+    }
+    return -1; // fail
+  } else {
+    // interrupt handler registration
+    if(index >= 0 && index < INTERRUPT_TOTAL) {
+      interrupt_handler[index] = handler;
+      return 0; // success
+    }
+    else {
+      return -1; // fail
+    }
+  }
+}
+
+void bp_trap_handler(uint64_t *regs, uint64_t mcause, uint64_t instr)
+{
+  int is_interrupt = !!(mcause & (1UL << 63));
+  int index = mcause & ~(1UL << 63);
+  if(is_interrupt) {
+    if(index >= 0 && index < INTERRUPT_TOTAL)
+      interrupt_handler[index](regs, mcause, instr);
+    else {
+      // illegal trap code
+      bp_unhandled_trap_abort(regs, mcause, instr);
+    }
+  } else {
+    if(index >= 0 && index < EXCEPTION_TOTAL)
+      exception_handler[index](regs, mcause, instr);
+    else {
+      // illegal trap code
+      bp_unhandled_trap_abort(regs, mcause, instr);
+    }
+  }
+}
+

--- a/bp_trap.c
+++ b/bp_trap.c
@@ -42,18 +42,20 @@ static void (*interrupt_handler[INTERRUPT_TOTAL])(uint64_t *, uint64_t, uint64_t
 };
 
 int register_trap_handler(void (*handler)(uint64_t *, uint64_t, uint64_t),
-        int index, int is_exception)
+        unsigned long mcause)
 {
+  unsigned index = mcause & ~(1UL << 63);
+  int is_exception = !(mcause & (1UL << 63));
   if(is_exception) {
     // exception handler registration
-    if(index >= 0 && index < EXCEPTION_TOTAL) {
+    if(index < EXCEPTION_TOTAL) {
       exception_handler[index] = handler;
       return 0; // success
     }
     return -1; // fail
   } else {
     // interrupt handler registration
-    if(index >= 0 && index < INTERRUPT_TOTAL) {
+    if(index < INTERRUPT_TOTAL) {
       interrupt_handler[index] = handler;
       return 0; // success
     }

--- a/bp_trap.h
+++ b/bp_trap.h
@@ -1,0 +1,6 @@
+#ifndef BP_TRAP_H
+#define BP_TRAP_H
+int register_trap_handler(void (*handler)(uint64_t *, uint64_t, uint64_t),
+        int index, int is_exception);
+void bp_trap_handler(uint64_t *regs, uint64_t mcause, uint64_t instr);
+#endif

--- a/bp_trap.h
+++ b/bp_trap.h
@@ -1,5 +1,6 @@
 #ifndef BP_TRAP_H
 #define BP_TRAP_H
+#include <stdint.h>
 int register_trap_handler(void (*handler)(uint64_t *, uint64_t, uint64_t),
         unsigned long mcause);
 void bp_trap_handler(uint64_t *regs, uint64_t mcause, uint64_t instr);

--- a/bp_trap.h
+++ b/bp_trap.h
@@ -1,6 +1,6 @@
 #ifndef BP_TRAP_H
 #define BP_TRAP_H
 int register_trap_handler(void (*handler)(uint64_t *, uint64_t, uint64_t),
-        int index, int is_exception);
+        unsigned long mcause);
 void bp_trap_handler(uint64_t *regs, uint64_t mcause, uint64_t instr);
 #endif

--- a/emulation.c
+++ b/emulation.c
@@ -82,6 +82,11 @@ void bp_emulate_illegal_instruction(uint64_t *regs, uint64_t mcause, uint64_t in
     bp_dump_trap_context(mcause, instr);
     bp_panic("\nIllegal instruction\n");
   }
+  // Success. Now move mepc to next instruction
+  unsigned long mepc;
+  __asm__ __volatile__ ("csrr %0, mepc" : "=r"(mepc));
+  mepc += 4;
+  __asm__ __volatile__ ("csrw mepc, %0" : : "r"(mepc));
 }
 
 void bp_unhandled_trap_abort(uint64_t *regs, uint64_t mcause, uint64_t mtval) {

--- a/exception.S
+++ b/exception.S
@@ -4,8 +4,6 @@
 .align 1
 .globl __mtvec_handler
 
-#define MCAUSE_ILLEGAL_INSTRUCTION 0x2
-
 __mtvec_handler:
     # Swap in the machine mode stack pointer
     # Note: We only need to save the stack if we have a special emu stack. Security?
@@ -60,20 +58,7 @@ __mtvec_handler:
     # Read the trap value
     csrr a2, mtval
 
-    # return from handler directly to .Lfinish
-    la ra, .Lfinish
-
-    # Invoke the appropriate handler
-    li t0, MCAUSE_ILLEGAL_INSTRUCTION
-    beq a1, t0, bp_emulate_illegal_instruction
-    j bp_unhandled_trap_abort
-
-.Lfinish:
-
-    # Return address is the instruction after MEPC
-    csrr t0, mepc
-    addi t0, t0, 4
-    csrw mepc, t0
+    call bp_trap_handler
 
     # Pop temp registers from stack
     addi sp, sp, 256


### PR DESCRIPTION
This PR adds a generic trap handler for all kinds of interrupts and adds an interface for perch users to register their own interrupt handlers.

This PR addresses issue https://github.com/black-parrot-sdk/perch/issues/9.

Summary of the changes:

- In previous version interrupt code checking and mepc forwarding(+=4) were done in exception.S. Now the checking goes into the new generic handler -- bp_trap_handler, and the mepc forwarding goes into bp_emulate_illegal_instruction.
- A new generic handler -- bp_trap_handler is added.
- Now users can register their own handler(s) through register_trap_handler() in bp_trap.c.

Verification Status:
- Able to register and run my own s-mode interrupt handler in my LWIP application on FPGA.
- Haven't checked the interrupt path for the illegal instruction emulation. After verifying this, this PR should be all set.