### PR TITLE
Adding bp_asm.h

### DIFF
--- a/bp_asm.h
+++ b/bp_asm.h
@@ -1,0 +1,35 @@
+#ifndef BP_ASM_H
+#define BP_ASM_H
+
+#include "encoding.h"
+
+#define cbo_inval_block(addr) ({ \
+  __asm__ __volatile__ (".insn i 0x0f, 0b010, x0, %0, 0x0" : : "r" (addr)); \
+  })
+
+#define cbo_clean_block(addr) ({ \
+  __asm__ __volatile__ (".insn i 0x0f, 0b010, x0, %0, 0x1" : : "r" (addr)); \
+  })
+
+#define cbo_flush_block(addr) ({ \
+  __asm__ __volatile__ (".insn i 0x0f, 0b010, x0, %0, 0x2" : : "r" (addr)); \
+  })
+
+#define cbo_zero_block(addr) ({ \
+  __asm__ __volatile__ (".insn i 0x0f, 0b010, x0, %0, 0x4" : : "r" (addr)); \
+  })
+
+#define cbo_inval_all() ({ \
+  __asm__ __volatile__ (".insn i 0x0f, 0b111, x0, x0, 0x0" : :); \
+  })
+
+#define cbo_clean_all() ({ \
+  __asm__ __volatile__ (".insn i 0x0f, 0b111, x0, x0, 0x1" : :); \
+  })
+
+#define cbo_flush_all() ({ \
+  __asm__ __volatile__ (".insn i 0x0f, 0b111, x0, x0, 0x2" : :); \
+  })
+
+#endif
+

--- a/bp_utils.h
+++ b/bp_utils.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include "bsg_newlib_intf.h"
+#include "bp_asm.h"
 #include "bp_aviary.h"
 #include "bp_config.h"
 #include "bp_host.h"


### PR DESCRIPTION
This PR adds bp_asm.h which provides the riscv-opcodes encoding.h primitives as well as custom bp defines