### PR TITLE
parameterize march and mabi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 
-RISCV_GCC = $(CROSS_COMPILE)gcc -fPIC -march=rv64gc -mabi=lp64d -mcmodel=medany -static -I$(BP_SDK_INCLUDE_DIR)
+WITH_MARCH ?= rv64gc
+WITH_MABI ?= lp64d
+
+RISCV_GCC = $(CROSS_COMPILE)gcc -fPIC -march=$(WITH_MARCH) -mabi=$(WITH_MABI) -mcmodel=medany -static -I$(BP_SDK_INCLUDE_DIR)
 RISCV_AR = $(CROSS_COMPILE)ar
 RISCV_RANLIB = $(CROSS_COMPILE)ranlib
 
@@ -9,7 +12,6 @@ perch:
 	$(RISCV_GCC) -c *.c *.S
 	$(RISCV_AR) -rc libperch.a *.o
 	$(RISCV_RANLIB) libperch.a
-	
 	$(RISCV_GCC) -c -DBAREMETAL *.c *.S
 	$(RISCV_AR) -rc libperchbm.a *.o
 	$(RISCV_RANLIB) libperchbm.a


### PR DESCRIPTION
Add Makefile flags to allow -march and -mabi option override when compiling the bootrom image.

BP supports the "C" extension through a parameter and therefore the toolchain should also support a way to compile programs with or without the extension. This change allows the user to specify whether their machine target uses "C" or not.